### PR TITLE
fix(pipeline): add mono installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           go-version: ">=1.20.1"
           cache: true
+      - name: Install mono
+        run: sudo apt-get update && sudo apt-get install -y mono-devel
       - name: install chocolatey
         run: |
           mkdir -p /opt/chocolatey


### PR DESCRIPTION
to resolve Chocolatey error in release workflow

This resolves the issue where the pipeline failed with the error: 'mono: command not found'.

resolves #47 