### PR TITLE
 chore: Add pre-commit hook config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: tfsort
+  name: tfsort
+  description: This hook uses github.com/AlexNabokikh/tfsort to sort terraform files
+  entry: tfsort
+  language: golang
+  files: \.(tf|tofu)$
+  exclude: \.terraform/.*$


### PR DESCRIPTION
This allows using tfsort as a [pre-commit](https://github.com/pre-commit/pre-commit) hook.

Example configuration:

```yaml
repos:
  - repo: https://github.com/AlexNabokikh/tfsort
    rev: master
    hooks:
      - id: tfsort
```